### PR TITLE
Add script to parse amass output

### DIFF
--- a/parse_amass/__init__.py
+++ b/parse_amass/__init__.py
@@ -1,0 +1,77 @@
+import argparse
+import ipaddress
+from urllib.parse import urlparse
+from typing import Dict, List, Tuple, Optional
+
+
+def categorize_entry(entry: str) -> Optional[Tuple[str, str]]:
+    """Categorize a single line from amass output.
+
+    Returns a tuple of (category, value) or None if the line is empty.
+    Categories are "ips", "fqdns", and "urls".
+    """
+    line = entry.strip()
+    if not line:
+        return None
+
+    # Check for IP address
+    try:
+        ipaddress.ip_address(line)
+        return "ips", line
+    except ValueError:
+        pass
+
+    # Check for URL
+    parsed = urlparse(line)
+    if parsed.scheme and parsed.netloc:
+        return "urls", line
+
+    # Treat everything else as FQDN
+    return "fqdns", line
+
+
+def parse_file(path: str) -> Dict[str, List[str]]:
+    """Parse an amass output file into categorized lists."""
+    categories: Dict[str, List[str]] = {"ips": [], "fqdns": [], "urls": []}
+    with open(path, "r", encoding="utf8") as f:
+        for line in f:
+            result = categorize_entry(line)
+            if result is None:
+                continue
+            category, value = result
+            categories[category].append(value)
+    return categories
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Parse amass output into categories.")
+    parser.add_argument("input", help="Path to the amass output file")
+    parser.add_argument("--ips", help="File to write IP addresses to")
+    parser.add_argument("--fqdns", help="File to write FQDNs to")
+    parser.add_argument("--urls", help="File to write URLs to")
+    args = parser.parse_args()
+
+    categories = parse_file(args.input)
+
+    if args.ips:
+        with open(args.ips, "w", encoding="utf8") as f:
+            f.write("\n".join(categories["ips"]))
+    if args.fqdns:
+        with open(args.fqdns, "w", encoding="utf8") as f:
+            f.write("\n".join(categories["fqdns"]))
+    if args.urls:
+        with open(args.urls, "w", encoding="utf8") as f:
+            f.write("\n".join(categories["urls"]))
+
+    if not any([args.ips, args.fqdns, args.urls]):
+        for key, values in categories.items():
+            if not values:
+                continue
+            print(f"{key}:")
+            for value in values:
+                print(value)
+            print()
+
+
+if __name__ == "__main__":
+    main()

--- a/parse_amass/__main__.py
+++ b/parse_amass/__main__.py
@@ -1,0 +1,4 @@
+from . import main
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_parse_amass.py
+++ b/tests/test_parse_amass.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+# Ensure the package root is on the Python path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from parse_amass import categorize_entry, parse_file
+
+
+def test_categorize_entry():
+    assert categorize_entry("192.168.0.1")[0] == "ips"
+    assert categorize_entry("https://example.com")[0] == "urls"
+    assert categorize_entry("www.example.com")[0] == "fqdns"
+
+
+def test_parse_file(tmp_path):
+    content = "\n".join([
+        "192.168.1.1",
+        "example.com",
+        "https://sub.example.com/path",
+    ])
+    input_file = tmp_path / "amass.txt"
+    input_file.write_text(content)
+    categories = parse_file(str(input_file))
+    assert categories["ips"] == ["192.168.1.1"]
+    assert categories["fqdns"] == ["example.com"]
+    assert categories["urls"] == ["https://sub.example.com/path"]


### PR DESCRIPTION
## Summary
- implement `parse_amass` package to categorize entries as IPs, FQDNs, or URLs
- add CLI and supporting tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68941fd2fd708320957cda5f90a8a5bf