### PR TITLE
Add personnel_scrubber package with SQLite tracker, CLI, example rules, and README

### DIFF
--- a/personnel_scrubber/README.md
+++ b/personnel_scrubber/README.md
@@ -1,0 +1,135 @@
+# Personnel Data Removal Tool (Practical MVP)
+
+This folder contains a practical implementation blueprint and starter code for a local-first
+personnel data removal tool using Python, Playwright, and SQLite.
+
+## Scope
+
+The MVP focuses on:
+1. Discovering likely listings for a person.
+2. Running broker-specific opt-out workflows.
+3. Tracking lifecycle state for each broker/listing.
+4. Assisting with email confirmation links.
+5. Providing a simple local dashboard view.
+
+## Architecture
+
+### 1) Discovery module
+
+Use either:
+- search APIs (preferred for reliability and ToS alignment), or
+- browser automation for manual query execution.
+
+Queries:
+- `"First Last"`
+- `"Street Address, City, State"`
+- `"First Last" "City" "State"`
+
+Discovery output should normalize into candidate records:
+- `domain`
+- `search_query`
+- `listing_url`
+- `confidence`
+- `raw_snippet`
+
+### 2) Broker rules
+
+Each broker has one YAML file with:
+- `domain`
+- `search_url_pattern`
+- `opt_out_url`
+- `selectors`
+- `form_fields`
+- flags: `needs_email_confirmation`, `has_captcha`, `needs_exact_listing_url`
+
+See `rules/example_broker.yaml` for schema style.
+
+### 3) Workflow runner (Playwright)
+
+Per broker:
+1. Open search page or direct opt-out URL.
+2. Resolve the target listing URL.
+3. Fill and submit forms when deterministic.
+4. Pause for manual CAPTCHA if flagged.
+5. Resume and record status.
+
+Recommended status states:
+- `discovered`
+- `submitted`
+- `awaiting_email`
+- `confirmed`
+- `verified_removed`
+- `failed`
+
+### 4) Email confirmation helper
+
+Connect via IMAP to a dedicated mailbox.
+- Poll for broker messages from known senders/domains.
+- Extract and validate confirmation links.
+- Open link automatically only if host matches allowlist.
+
+### 5) Tracker dashboard
+
+A local UI can start as CLI + static HTML export.
+
+Columns:
+- domain
+- listing_found
+- removal_submitted
+- awaiting_email_click
+- verified
+- recheck_date
+- notes
+
+## Safety and legal notes
+
+- Respect site Terms of Service and anti-abuse policies.
+- Use conservative rate limiting and randomized delays.
+- Keep local encrypted storage for PII and audit logs.
+- Require explicit operator confirmation before destructive actions.
+
+## Suggested project layout
+
+```
+personnel_scrubber/
+  README.md
+  tracker.py
+  rules/
+    example_broker.yaml
+```
+
+`tracker.py` includes SQLite schema helpers for request lifecycle tracking.
+
+
+## Download and run
+
+### 1) Get the code
+
+```bash
+git clone <your-repo-url>
+cd github
+```
+
+### 2) Initialize a local tracker DB
+
+```bash
+python -m personnel_scrubber.cli --db scrubber.db init-db
+```
+
+### 3) Add a removal row
+
+```bash
+python -m personnel_scrubber.cli --db scrubber.db add   --domain examplebroker.com   --listing-url https://examplebroker.com/profile/abc   --listing-found   --submitted   --awaiting-email   --recheck-date 2026-04-15   --notes "Submitted and waiting for confirmation email"
+```
+
+### 4) List tracked rows
+
+```bash
+python -m personnel_scrubber.cli --db scrubber.db list
+```
+
+## What this gives you today
+
+- Working local persistence for request tracking.
+- An editable per-broker rule format in YAML.
+- A CLI workflow for init/add/list while Playwright + email automation is added next.

--- a/personnel_scrubber/__init__.py
+++ b/personnel_scrubber/__init__.py
@@ -1,0 +1,1 @@
+"""Personnel scrubber package."""

--- a/personnel_scrubber/cli.py
+++ b/personnel_scrubber/cli.py
@@ -1,0 +1,82 @@
+"""Simple CLI for the personnel scrubber SQLite tracker."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+from pathlib import Path
+
+from personnel_scrubber.tracker import RemovalRecord, connect, init_db, insert_removal, list_removals
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="personnel-scrubber")
+    parser.add_argument("--db", default="scrubber.db", help="SQLite database path (default: scrubber.db)")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("init-db", help="Create tracker tables")
+
+    add_parser = subparsers.add_parser("add", help="Add a domain/listing tracking row")
+    add_parser.add_argument("--domain", required=True)
+    add_parser.add_argument("--listing-url", default="")
+    add_parser.add_argument("--listing-found", action="store_true")
+    add_parser.add_argument("--submitted", action="store_true")
+    add_parser.add_argument("--awaiting-email", action="store_true")
+    add_parser.add_argument("--verified", action="store_true")
+    add_parser.add_argument("--recheck-date", default="", help="YYYY-MM-DD")
+    add_parser.add_argument("--notes", default="")
+
+    subparsers.add_parser("list", help="List tracked rows")
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    db_path = Path(args.db)
+    conn = connect(db_path)
+
+    if args.command == "init-db":
+        init_db(conn)
+        print(f"Initialized database: {db_path}")
+        return
+
+    if args.command == "add":
+        init_db(conn)
+        recheck = date.fromisoformat(args.recheck_date) if args.recheck_date else None
+        record = RemovalRecord(
+            domain=args.domain,
+            listing_url=args.listing_url,
+            listing_found=args.listing_found,
+            removal_submitted=args.submitted,
+            awaiting_email_click=args.awaiting_email,
+            verified=args.verified,
+            recheck_date=recheck,
+            notes=args.notes,
+        )
+        row_id = insert_removal(conn, record)
+        print(f"Inserted record id={row_id} for domain={args.domain}")
+        return
+
+    if args.command == "list":
+        init_db(conn)
+        rows = list_removals(conn)
+        if not rows:
+            print("No records found.")
+            return
+        for row in rows:
+            print(
+                f"#{row['id']} {row['domain']} | found={row['listing_found']} submitted={row['removal_submitted']} "
+                f"awaiting_email={row['awaiting_email_click']} verified={row['verified']} "
+                f"recheck={row['recheck_date'] or '-'} listing={row['listing_url'] or '-'}"
+            )
+        return
+
+    parser.error(f"Unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    main()

--- a/personnel_scrubber/rules/example_broker.yaml
+++ b/personnel_scrubber/rules/example_broker.yaml
@@ -1,0 +1,32 @@
+domain: "examplebroker.com"
+search_url_pattern: "https://www.examplebroker.com/search?name={name}&city={city}&state={state}"
+opt_out_url: "https://www.examplebroker.com/opt-out"
+needs_email_confirmation: true
+has_captcha: true
+needs_exact_listing_url: true
+
+selectors:
+  search_result_links: "a.result-link"
+  listing_name: "h1.profile-name"
+  opt_out_form: "form#optout"
+  submit_button: "button[type='submit']"
+
+form_fields:
+  first_name:
+    selector: "input[name='firstName']"
+    source: "first_name"
+  last_name:
+    selector: "input[name='lastName']"
+    source: "last_name"
+  email:
+    selector: "input[name='email']"
+    source: "notification_email"
+  listing_url:
+    selector: "input[name='listingUrl']"
+    source: "listing_url"
+
+email_confirmation:
+  allowed_sender_domains:
+    - "examplebroker.com"
+  confirmation_link_patterns:
+    - "https://www.examplebroker.com/confirm"

--- a/personnel_scrubber/tracker.py
+++ b/personnel_scrubber/tracker.py
@@ -1,0 +1,93 @@
+"""SQLite tracker for personnel data removal workflow state."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Iterable
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS removals (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    domain TEXT NOT NULL,
+    listing_url TEXT,
+    listing_found INTEGER NOT NULL DEFAULT 0,
+    removal_submitted INTEGER NOT NULL DEFAULT 0,
+    awaiting_email_click INTEGER NOT NULL DEFAULT 0,
+    verified INTEGER NOT NULL DEFAULT 0,
+    recheck_date TEXT,
+    notes TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_removals_domain ON removals(domain);
+CREATE INDEX IF NOT EXISTS idx_removals_verified ON removals(verified);
+"""
+
+
+@dataclass(frozen=True)
+class RemovalRecord:
+    domain: str
+    listing_url: str = ""
+    listing_found: bool = False
+    removal_submitted: bool = False
+    awaiting_email_click: bool = False
+    verified: bool = False
+    recheck_date: date | None = None
+    notes: str = ""
+
+
+def connect(db_path: str | Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db(conn: sqlite3.Connection) -> None:
+    conn.executescript(SCHEMA)
+    conn.commit()
+
+
+def insert_removal(conn: sqlite3.Connection, record: RemovalRecord) -> int:
+    cur = conn.execute(
+        """
+        INSERT INTO removals (
+            domain,
+            listing_url,
+            listing_found,
+            removal_submitted,
+            awaiting_email_click,
+            verified,
+            recheck_date,
+            notes
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            record.domain,
+            record.listing_url,
+            int(record.listing_found),
+            int(record.removal_submitted),
+            int(record.awaiting_email_click),
+            int(record.verified),
+            record.recheck_date.isoformat() if record.recheck_date else None,
+            record.notes,
+        ),
+    )
+    conn.commit()
+    return int(cur.lastrowid)
+
+
+def list_removals(conn: sqlite3.Connection) -> Iterable[sqlite3.Row]:
+    return conn.execute(
+        """
+        SELECT id, domain, listing_url, listing_found, removal_submitted,
+               awaiting_email_click, verified, recheck_date, notes,
+               created_at, updated_at
+        FROM removals
+        ORDER BY verified ASC, domain ASC
+        """
+    ).fetchall()


### PR DESCRIPTION
### Motivation

- Provide a local-first practical MVP for tracking and running personnel data removal workflows with a simple on-disk tracker and CLI. 
- Define a per-broker rule format and workflow primitives to support automated and semi-automated opt-out flows. 
- Ship starter documentation and scaffolding so Playwright/email automation can be integrated next.

### Description

- Add `personnel_scrubber/tracker.py` which implements an SQLite schema, `RemovalRecord` dataclass, and helper functions `connect`, `init_db`, `insert_removal`, and `list_removals`.
- Add a minimal CLI in `personnel_scrubber/cli.py` providing `init-db`, `add`, and `list` commands and wiring to the tracker functions.
- Add an example broker rule at `personnel_scrubber/rules/example_broker.yaml` demonstrating the YAML schema for broker metadata, selectors, form fields, and email confirmation hints.
- Add `personnel_scrubber/README.md` documenting architecture, workflow, recommended states, usage examples, and a suggested project layout, and add package `__init__.py`.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5224e975c83208ca9cb775c17db9a)